### PR TITLE
Add replaceOptions call to struct parsing

### DIFF
--- a/src/main/java/com/sovdee/oopsk/elements/structures/StructStructTemplate.java
+++ b/src/main/java/com/sovdee/oopsk/elements/structures/StructStructTemplate.java
@@ -1,5 +1,6 @@
 package com.sovdee.oopsk.elements.structures;
 
+import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.config.Node;
@@ -121,7 +122,7 @@ public class StructStructTemplate extends Structure {
         for (Node child : node) {
             if (child instanceof SimpleNode simpleNode) {
                 // match the field pattern
-                String key = simpleNode.getKey();
+                String key = ScriptLoader.replaceOptions(simpleNode.getKey());
                 Matcher matcher;
                 if (key == null || !(matcher = fieldPattern.matcher(key)).matches()) {
                     Skript.error("invalid field: " + key);

--- a/src/test/scripts/basics.sk
+++ b/src/test/scripts/basics.sk
@@ -1,13 +1,18 @@
+options:
+    a: 17
+
 struct basic:
     a: int
     b: strings
     c: entitytype = cow
+    d{@a}: number = {@a}
 
 test "basic struct behavior":
     set {_struct} to a basic struct
     assert {_struct}->a is not set with "struct field a was somehow set"
     assert {_struct}->b is not set with "struct field b was somehow set"
     assert {_struct}->c is a cow with "struct field c was not set to cow"
+    assert {_struct}->d{@a} is {@a} with "struct field {@a} was not set to {@a}"
 
     set {_struct}->a to 1
     assert {_struct}->a is 1 with "struct field a was not set to 1"


### PR DESCRIPTION
Replaces options in struct field definitions since it is not done automatically.
Closes #16