### PR TITLE
Allow single Object fields to accept any type in acceptChange

### DIFF
--- a/src/main/java/com/sovdee/oopsk/elements/expressions/ExprFieldAccess.java
+++ b/src/main/java/com/sovdee/oopsk/elements/expressions/ExprFieldAccess.java
@@ -177,11 +177,6 @@ public class ExprFieldAccess extends PropertyExpression<Struct, Object> implemen
             // return all return types
             return Arrays.stream(returnTypes).map(Class::arrayType).toArray(Class<?>[]::new);
 
-        // if a field is single and object, it should allow object stuff
-        if (isAnyFieldSingle && returnType == Object.class) {
-            return new Class<?>[]{Object.class};
-        }
-
         // if the mode is set, always allow changes
         if (mode == ChangeMode.SET)
             // return all return types
@@ -189,6 +184,11 @@ public class ExprFieldAccess extends PropertyExpression<Struct, Object> implemen
 
         // if we have a single field, we can delegate to that type's changer, so get all the classes from the changers
         if (isAnyFieldSingle) {
+            // if a field is single and object, it should accept all changers
+            if (returnType == Object.class) {
+                return new Class<?>[]{Object.class};
+            }
+
             Set<Class<?>> distinctClasses = Arrays.stream(returnTypes)
                     .map(Classes::getSuperClassInfo)
                     .filter(Objects::nonNull)


### PR DESCRIPTION
This PR ensures that single `Object` fields in `ExprFieldAccess#acceptChange` are always accepted as `Object.class`.

Fixes #18 