### PR TITLE
Concrete types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     id 'java'
+    id 'skript-test' version('1.0.1')
+    id 'com.gradleup.shadow' version('9.2.2')
 }
 
 group = 'com.sovdee'
@@ -12,6 +14,7 @@ test {
 
 repositories {
     mavenCentral()
+    mavenLocal()
     maven {
         url 'https://repo.papermc.io/repository/maven-public/'
     }
@@ -21,14 +24,31 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-
     compileOnly 'org.spigotmc:spigot-api:1.21.4-R0.1-SNAPSHOT'
-    compileOnly "com.github.SkriptLang:Skript:2.11.0"
+    compileOnly "com.github.SkriptLang:Skript:2.12.2"
     compileOnly 'org.jetbrains:annotations:26.0.1'
+    implementation 'net.bytebuddy:byte-buddy:1.14.18' // for runtime code generation
 }
 
 processResources {
     filter ReplaceTokens, tokens: ["version": project.property("version")]
+}
+
+shadowJar {
+    relocate 'net.bytebuddy', 'com.sovdee.oopsk.bytebuddy'
+    minimize()
+    archiveClassifier.set('')
+}
+
+build {
+    dependsOn shadowJar
+}
+
+
+skriptTest {
+    dependsOn build
+    testScriptDirectory = file("src/test/scripts")
+    extraPluginsDirectory = new File("./build/libs")
+    skriptRepoRef = "dev/patch"
+    runVanillaTests = false
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,10 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'oopsk'
+
+

--- a/src/main/java/com/sovdee/oopsk/Oopsk.java
+++ b/src/main/java/com/sovdee/oopsk/Oopsk.java
@@ -5,6 +5,7 @@ import ch.njol.skript.SkriptAddon;
 import ch.njol.skript.bstats.bukkit.Metrics;
 import com.sovdee.oopsk.core.StructManager;
 import com.sovdee.oopsk.core.TemplateManager;
+import com.sovdee.oopsk.core.generation.TemporaryClassManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.IOException;
@@ -16,6 +17,7 @@ public final class Oopsk extends JavaPlugin {
     private static SkriptAddon addon;
     private static StructManager structManager;
     private static TemplateManager templateManager;
+    private static TemporaryClassManager classManager = new TemporaryClassManager();
     private static Logger logger;
 
     public static Oopsk getInstance() {
@@ -32,6 +34,10 @@ public final class Oopsk extends JavaPlugin {
 
     public static TemplateManager getTemplateManager() {
         return templateManager;
+    }
+
+    public static TemporaryClassManager getClassManager() {
+        return classManager;
     }
 
     public static void info(String message) {

--- a/src/main/java/com/sovdee/oopsk/core/Struct.java
+++ b/src/main/java/com/sovdee/oopsk/core/Struct.java
@@ -22,6 +22,33 @@ public class Struct {
     private StructTemplate template;
     private final Map<Field<?>, Object[]> fieldValues;
 
+    public static Struct newInstance(@NotNull StructTemplate template, @Nullable Event event) {
+        Class<? extends Struct> structClass = template.getCustomClass();
+        try {
+            return structClass.getDeclaredConstructor(StructTemplate.class, Event.class).newInstance(template, event);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create new instance of struct class " + structClass.getName(), e);
+        }
+    }
+
+    public static Struct newInstance(Struct source) {
+        Class<? extends Struct> structClass = source.getTemplate().getCustomClass();
+        try {
+            return structClass.getDeclaredConstructor(Struct.class).newInstance(source);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create new instance of struct class " + structClass.getName(), e);
+        }
+    }
+
+    public static Struct newInstance(@NotNull StructTemplate template, @Nullable Event event, @Nullable Map<String, Expression<?>> initialValues) {
+        Class<? extends Struct> structClass = template.getCustomClass();
+        try {
+            return structClass.getDeclaredConstructor(StructTemplate.class, Event.class, Map.class).newInstance(template, event, initialValues);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create new instance of struct class " + structClass.getName(), e);
+        }
+    }
+
     /**
      * Creates a new struct with the given template and event.
      *
@@ -29,7 +56,7 @@ public class Struct {
      * @param event    The event to evaluate the default values in.
      * @see StructManager#createStruct(StructTemplate, Event)
      */
-    public Struct(@NotNull StructTemplate template, @Nullable Event event) {
+    protected Struct(@NotNull StructTemplate template, @Nullable Event event) {
         this.template = template;
         fieldValues = new HashMap<>();
         for (Field<?> field : template.getFields()) {
@@ -44,7 +71,7 @@ public class Struct {
      * @param source The struct to copy from.
      * @see StructManager#createStruct(StructTemplate, Event)
      */
-    public Struct(Struct source) {
+    protected Struct(Struct source) {
         this.template = source.template;
         fieldValues = new HashMap<>();
         for (Map.Entry<Field<?>, Object[]> entry : source.fieldValues.entrySet()) {
@@ -64,7 +91,7 @@ public class Struct {
      * @param initialValues The initial values to set in the struct. This is a map of field names to expressions.
      * @see StructManager#createStruct(StructTemplate, Event)
      */
-    Struct(@NotNull StructTemplate template, @Nullable Event event, @Nullable Map<String, Expression<?>> initialValues) {
+    protected Struct(@NotNull StructTemplate template, @Nullable Event event, @Nullable Map<String, Expression<?>> initialValues) {
         this.template = template;
         fieldValues = new HashMap<>();
         for (Field<?> field : template.getFields()) {

--- a/src/main/java/com/sovdee/oopsk/core/StructManager.java
+++ b/src/main/java/com/sovdee/oopsk/core/StructManager.java
@@ -41,7 +41,7 @@ public class StructManager {
      * @return The created struct.
      */
     public Struct createStruct(StructTemplate template, @Nullable Event event, @Nullable Map<String, Expression<?>> initialValues) {
-        Struct struct = new Struct(template, event, initialValues);
+        Struct struct = Struct.newInstance(template, event, initialValues);
         activeStructs.computeIfAbsent(template, k -> Collections.newSetFromMap(new WeakHashMap<>())).add(struct);
         return struct;
     }

--- a/src/main/java/com/sovdee/oopsk/core/StructTemplate.java
+++ b/src/main/java/com/sovdee/oopsk/core/StructTemplate.java
@@ -14,6 +14,7 @@ import java.util.Map;
 public class StructTemplate {
     private final String name;
     private final Map<String, Field<?>> fields;
+    private final Class<? extends Struct> customClass;
 
     /**
      * Creates a new struct template with the given name and fields.
@@ -21,8 +22,9 @@ public class StructTemplate {
      * @param name   The name of the template.
      * @param fields The fields of the template.
      */
-    public StructTemplate(String name, @NotNull List<Field<?>> fields) {
+    public StructTemplate(String name, @NotNull List<Field<?>> fields, Class<? extends Struct> customClass) {
         this.name = name;
+        this.customClass = customClass;
         this.fields = new HashMap<>();
         for (Field<?> field : fields) {
             this.fields.put(field.name(), field);
@@ -34,6 +36,13 @@ public class StructTemplate {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * @return The custom class for this struct, or null if none was specified.
+     */
+    public Class<? extends Struct> getCustomClass() {
+        return customClass;
     }
 
     /**

--- a/src/main/java/com/sovdee/oopsk/core/TemplateManager.java
+++ b/src/main/java/com/sovdee/oopsk/core/TemplateManager.java
@@ -18,6 +18,7 @@ import java.util.function.Predicate;
 public class TemplateManager {
 
     private final Map<String, StructTemplate> templates = new HashMap<>();
+    private final Map<Class<? extends Struct>, StructTemplate> templatesByClass = new HashMap<>();
 
     /**
      * Adds a new template to the manager. Attempts to reparent all orphaned structs that match this template's name.
@@ -29,6 +30,7 @@ public class TemplateManager {
         if (templates.containsKey(template.getName()))
             return false; // Template with the same name already exists
         templates.put(template.getName(), template);
+        templatesByClass.put(template.getCustomClass(), template);
         // reparent all orphaned structs of this template
         Oopsk.getStructManager().reparentStructs(template);
         return true; // Template added successfully
@@ -45,6 +47,16 @@ public class TemplateManager {
     }
 
     /**
+     * Retrieves a template by class.
+     *
+     * @param structClass The name of the template to retrieve.
+     * @return The template, or null if it does not exist.
+     */
+    public StructTemplate getTemplate(Class<?extends Struct> structClass) {
+        return templatesByClass.get(structClass);
+    }
+
+    /**
      * Removes a template from the manager. This will orphan all structs of this template.
      *
      * @param template The template to remove.
@@ -54,6 +66,7 @@ public class TemplateManager {
         if (!templates.containsKey(name))
             return; // Template with the given name does not exist
         templates.remove(name);
+        templatesByClass.remove(template.getCustomClass());
         // mark all structs of this template as orphaned
         Oopsk.getStructManager().orphanStructs(template);
     }

--- a/src/main/java/com/sovdee/oopsk/core/generation/ReflectionUtils.java
+++ b/src/main/java/com/sovdee/oopsk/core/generation/ReflectionUtils.java
@@ -1,0 +1,141 @@
+package com.sovdee.oopsk.core.generation;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.localization.Language;
+import ch.njol.skript.registrations.Classes;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+public class ReflectionUtils {
+
+    private static final Field tempClassInfosField;
+    private static final Field exactClassInfosField;
+    private static final Field classInfosByCodeNameField;
+    private static final Field acceptRegistrationsField;
+    private static final Field localizedLanguageField;
+    private static final Field classInfosField;
+    private static final Method sortClassInfosMethod;
+
+    static {
+        try {
+            // Get the fields once during class initialization
+            tempClassInfosField = Classes.class.getDeclaredField("tempClassInfos");
+            exactClassInfosField = Classes.class.getDeclaredField("exactClassInfos");
+            classInfosByCodeNameField = Classes.class.getDeclaredField("classInfosByCodeName");
+            acceptRegistrationsField = Skript.class.getDeclaredField("acceptRegistrations");
+            localizedLanguageField = Language.class.getDeclaredField("localizedLanguage");
+            classInfosField = Classes.class.getDeclaredField("classInfos");
+
+            // Get the method
+            sortClassInfosMethod = Classes.class.getDeclaredMethod("sortClassInfos");
+
+
+            // Make them accessible
+            tempClassInfosField.setAccessible(true);
+            exactClassInfosField.setAccessible(true);
+            classInfosByCodeNameField.setAccessible(true);
+            acceptRegistrationsField.setAccessible(true);
+            localizedLanguageField.setAccessible(true);
+            classInfosField.setAccessible(true);
+            sortClassInfosMethod.setAccessible(true);
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to access fields", e);
+        }
+    }
+
+    public static void enableRegistrations() {
+        setFieldValue(true);
+    }
+
+    public static void disableRegistrations() {
+        setFieldValue(false);
+    }
+
+    private static void setFieldValue(boolean value) {
+        try {
+            acceptRegistrationsField.set(null, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to modify acceptRegistrations field", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<ClassInfo<?>> getTempClassInfos() throws Exception {
+        return (List<ClassInfo<?>>) tempClassInfosField.get(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static HashMap<Class<?>, ClassInfo<?>> getExactClassInfos() throws Exception {
+        return (HashMap<Class<?>, ClassInfo<?>>) exactClassInfosField.get(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static HashMap<String, ClassInfo<?>> getClassInfosByCodeName() throws Exception {
+        return (HashMap<String, ClassInfo<?>>) classInfosByCodeNameField.get(null);
+    }
+
+    public static void addLanguageNode(String key, String value) {
+        try {
+            @SuppressWarnings("unchecked")
+            HashMap<String, String> langMap = (HashMap<String, String>) localizedLanguageField.get(null);
+            System.out.println("Adding language node: " + key + " -> " + value);
+            langMap.put(key, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to add language node.", e);
+        }
+    }
+
+    public static void removeLanguageNode(String key) {
+        try {
+            @SuppressWarnings("unchecked")
+            HashMap<String, String> langMap = (HashMap<String, String>) localizedLanguageField.get(null);
+            System.out.println("Removing language node: " + key + " (was " + langMap.get(key) + ")");
+            langMap.remove(key);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to add language node.", e);
+        }
+    }
+
+    public static void resortClassInfos(ClassInfo<?>... exclude) throws Exception {
+        var tempClassInfos = getTempClassInfos();
+        Collections.addAll(tempClassInfos, (ClassInfo<?>[]) classInfosField.get(null));
+        if (exclude != null && exclude.length > 0)
+            tempClassInfos.removeAll(List.of(exclude));
+        classInfosField.set(null, null);
+        sortClassInfos();
+    }
+
+    public static void sortClassInfos() throws Exception {
+        sortClassInfosMethod.invoke(null);
+    }
+
+    public static void addClassInfo(ClassInfo<?> classInfo) {
+        enableRegistrations();
+        Classes.registerClass(classInfo);
+        try {
+            resortClassInfos();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        System.out.println("Registered custom struct class: " + classInfo.getName());
+        disableRegistrations();
+    }
+
+    // Remove from all three collections
+    public static void removeClassInfo(ClassInfo<?> classInfo) {
+        try {
+            getExactClassInfos().remove(classInfo.getC());
+            getClassInfosByCodeName().remove(classInfo.getCodeName());
+            resortClassInfos(classInfo);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to remove classinfo.", e);
+        }
+    }
+
+}

--- a/src/main/java/com/sovdee/oopsk/core/generation/ReflectionUtils.java
+++ b/src/main/java/com/sovdee/oopsk/core/generation/ReflectionUtils.java
@@ -84,7 +84,6 @@ public class ReflectionUtils {
         try {
             @SuppressWarnings("unchecked")
             HashMap<String, String> langMap = (HashMap<String, String>) localizedLanguageField.get(null);
-            System.out.println("Adding language node: " + key + " -> " + value);
             langMap.put(key, value);
         } catch (Exception e) {
             throw new RuntimeException("Failed to add language node.", e);
@@ -95,7 +94,6 @@ public class ReflectionUtils {
         try {
             @SuppressWarnings("unchecked")
             HashMap<String, String> langMap = (HashMap<String, String>) localizedLanguageField.get(null);
-            System.out.println("Removing language node: " + key + " (was " + langMap.get(key) + ")");
             langMap.remove(key);
         } catch (Exception e) {
             throw new RuntimeException("Failed to add language node.", e);
@@ -123,7 +121,6 @@ public class ReflectionUtils {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        System.out.println("Registered custom struct class: " + classInfo.getName());
         disableRegistrations();
     }
 

--- a/src/main/java/com/sovdee/oopsk/core/generation/TemporaryClassManager.java
+++ b/src/main/java/com/sovdee/oopsk/core/generation/TemporaryClassManager.java
@@ -1,0 +1,42 @@
+package com.sovdee.oopsk.core.generation;
+
+import com.sovdee.oopsk.core.Struct;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class TemporaryClassManager {
+    private ClassLoader disposableClassLoader;
+
+    public TemporaryClassManager() {
+        resetClassLoader();
+    }
+
+    private void resetClassLoader() {
+        // Create a new child ClassLoader
+        this.disposableClassLoader = new URLClassLoader(
+                new URL[0],
+                Struct.class.getClassLoader()
+        );
+    }
+
+    public Class<?> createTemporarySubclass(String name) {
+        return new ByteBuddy()
+                .subclass(Struct.class)
+                .name(name)
+                .make()
+                .load(disposableClassLoader, ClassLoadingStrategy.Default.WRAPPER)
+                .getLoaded();
+    }
+
+    public void unloadAll() {
+        // Drop the ClassLoader and all its classes
+        disposableClassLoader = null;
+        System.gc(); // Suggest garbage collection
+
+        // Create a fresh ClassLoader for new classes
+        resetClassLoader();
+    }
+}

--- a/src/main/java/com/sovdee/oopsk/elements/expressions/ExprSecStructInstance.java
+++ b/src/main/java/com/sovdee/oopsk/elements/expressions/ExprSecStructInstance.java
@@ -138,8 +138,10 @@ public class ExprSecStructInstance extends SectionExpression<Struct> implements 
     @Override
     protected Struct @Nullable [] get(Event event) {
         StructTemplate template = Oopsk.getTemplateManager().getTemplate(name);
-        if (template == null)
+        if (template == null) {
             error("A struct by the name of '" + name + "' does not exist.");
+            return CollectionUtils.array();
+        }
         Struct struct = Oopsk.getStructManager().createStruct(template, event, parsedFieldValues);
         return CollectionUtils.array(struct);
     }

--- a/src/main/java/com/sovdee/oopsk/elements/expressions/ExprStructCopy.java
+++ b/src/main/java/com/sovdee/oopsk/elements/expressions/ExprStructCopy.java
@@ -12,16 +12,16 @@ public class ExprStructCopy extends SimplePropertyExpression<Struct, Struct> {
 
     @Override
     public @Nullable Struct convert(Struct struct) {
-        return new Struct(struct);
+        return Struct.newInstance(struct);
     }
 
     @Override
     public Class<? extends Struct> getReturnType() {
-        return Struct.class;
+        return getExpr().getReturnType();
     }
 
     @Override
     protected String getPropertyName() {
-        return "copy";
+        return "struct copy";
     }
 }

--- a/src/main/java/com/sovdee/oopsk/elements/expressions/ExprThisStruct.java
+++ b/src/main/java/com/sovdee/oopsk/elements/expressions/ExprThisStruct.java
@@ -10,10 +10,14 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
 import com.sovdee.oopsk.core.Struct;
+import com.sovdee.oopsk.elements.structures.StructStructTemplate;
 import com.sovdee.oopsk.events.DynamicFieldEvalEvent;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Array;
 
 @Name("This Struct")
 @Description("Usable only in dynamic field expressions, this refers to whatever struct is evaluating this field.")
@@ -30,6 +34,8 @@ public class ExprThisStruct extends SimpleExpression<Struct> {
         Skript.registerExpression(ExprThisStruct.class, Struct.class, ExpressionType.SIMPLE, "this [struct]");
     }
 
+    private Class<? extends Struct> structClass;
+
     @Override
     public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
         // check for right event
@@ -37,14 +43,20 @@ public class ExprThisStruct extends SimpleExpression<Struct> {
             Skript.error("The 'this struct' expression can only be used in a struct template definition.");
             return false;
         }
+        var structure = getParser().getCurrentStructure();
+        if (!(structure instanceof StructStructTemplate templateStructure)) {
+            Skript.error("The 'this struct' expression can only be used in a struct template definition.");
+            return false;
+        }
+        structClass = templateStructure.customClass;
         return true;
     }
 
     @Override
     protected Struct @Nullable [] get(Event event) {
         if (!(event instanceof DynamicFieldEvalEvent evalEvent))
-            return new Struct[0];
-        return new Struct[]{evalEvent.getStruct()};
+            return (Struct[]) Array.newInstance(structClass, 0);
+        return CollectionUtils.array(evalEvent.getStruct());
     }
 
     @Override
@@ -53,12 +65,13 @@ public class ExprThisStruct extends SimpleExpression<Struct> {
     }
 
     @Override
-    public Class<Struct> getReturnType() {
-        return Struct.class;
+    public Class<? extends Struct> getReturnType() {
+        return structClass;
     }
 
     @Override
     public String toString(@Nullable Event event, boolean debug) {
         return "this struct";
     }
+
 }

--- a/src/main/java/com/sovdee/oopsk/elements/structures/StructStructTemplate.java
+++ b/src/main/java/com/sovdee/oopsk/elements/structures/StructStructTemplate.java
@@ -20,7 +20,6 @@ import com.sovdee.oopsk.core.Field;
 import com.sovdee.oopsk.core.Field.Modifier;
 import com.sovdee.oopsk.core.Struct;
 import com.sovdee.oopsk.core.StructTemplate;
-import com.sovdee.oopsk.core.generation.TemporaryClassManager;
 import com.sovdee.oopsk.events.DynamicFieldEvalEvent;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
@@ -124,15 +123,12 @@ public class StructStructTemplate extends Structure {
         return templateManager.addTemplate(template);
     }
 
-    private TemporaryClassManager classManager;
     public Class<? extends Struct> customClass;
     public ClassInfo<?> customClassInfo;
 
     // this is a crime against humanity
     private void registerCustomType() {
-
-        assert classManager == null;
-        classManager = new TemporaryClassManager();
+        var classManager = Oopsk.getClassManager();
 
         // Create a dynamic subclass
         //noinspection unchecked
@@ -147,8 +143,6 @@ public class StructStructTemplate extends Structure {
 
         // hack open the Classes class to allow re-registration
         addClassInfo(customClassInfo);
-        System.out.println("By class: " + Classes.getExactClassInfo(customClass));
-        System.out.println("By user input: " + Classes.getClassInfoFromUserInput(name + " struct"));
     }
 
     private void unregisterCustomType() {
@@ -159,10 +153,6 @@ public class StructStructTemplate extends Structure {
             disableRegistrations();
             customClassInfo = null;
             customClass = null;
-        }
-        if (classManager != null) {
-            classManager.unloadAll();
-            classManager = null;
         }
     }
 

--- a/src/main/java/com/sovdee/oopsk/elements/structures/StructStructTemplate.java
+++ b/src/main/java/com/sovdee/oopsk/elements/structures/StructStructTemplate.java
@@ -18,7 +18,9 @@ import ch.njol.skript.util.Utils;
 import com.sovdee.oopsk.Oopsk;
 import com.sovdee.oopsk.core.Field;
 import com.sovdee.oopsk.core.Field.Modifier;
+import com.sovdee.oopsk.core.Struct;
 import com.sovdee.oopsk.core.StructTemplate;
+import com.sovdee.oopsk.core.generation.TemporaryClassManager;
 import com.sovdee.oopsk.events.DynamicFieldEvalEvent;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
@@ -34,6 +36,13 @@ import java.util.Set;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static com.sovdee.oopsk.core.generation.ReflectionUtils.addClassInfo;
+import static com.sovdee.oopsk.core.generation.ReflectionUtils.addLanguageNode;
+import static com.sovdee.oopsk.core.generation.ReflectionUtils.disableRegistrations;
+import static com.sovdee.oopsk.core.generation.ReflectionUtils.enableRegistrations;
+import static com.sovdee.oopsk.core.generation.ReflectionUtils.removeClassInfo;
+import static com.sovdee.oopsk.core.generation.ReflectionUtils.removeLanguageNode;
 
 @Name("Struct Template")
 @Description({
@@ -76,11 +85,10 @@ public class StructStructTemplate extends Structure {
         name = regex.group(1).trim().toLowerCase(Locale.ENGLISH);
         this.entryContainer = entryContainer;
 
-        return entryContainer != null;
-    }
+        if (entryContainer == null) {
+            return false;
+        }
 
-    @Override
-    public boolean preLoad() {
         SectionNode node = entryContainer.getSource();
 
         if (node.isEmpty()) {
@@ -88,32 +96,92 @@ public class StructStructTemplate extends Structure {
             return false;
         }
 
-        List<Field<?>> fields = getFields(node);
-
-        if (fields == null)
-            return false;
-
         var templateManager = Oopsk.getTemplateManager();
 
         if (templateManager.getTemplate(name) != null) {
             Skript.error("Struct by the name of " + name + " already exists.");
             return false;
         }
-        template = new StructTemplate(name, fields);
-        if (!templateManager.addTemplate(template))
+
+        registerCustomType(); // TODO: safety against name clashes
+
+        return true;
+    }
+
+    @Override
+    public boolean preLoad() {
+        SectionNode node = entryContainer.getSource();
+        var templateManager = Oopsk.getTemplateManager();
+
+        List<Field<?>> fields = getFields(node);
+
+        if (fields == null) {
+            unregisterCustomType();
             return false;
+        }
+
+        template = new StructTemplate(name, fields, customClass);
+        return templateManager.addTemplate(template);
+    }
+
+    private TemporaryClassManager classManager;
+    public Class<? extends Struct> customClass;
+    public ClassInfo<?> customClassInfo;
+
+    // this is a crime against humanity
+    private void registerCustomType() {
+
+        assert classManager == null;
+        classManager = new TemporaryClassManager();
+
+        // Create a dynamic subclass
+        //noinspection unchecked
+        customClass = (Class<? extends Struct>) classManager.createTemporarySubclass("Struct_"+ name.replaceAll("[^a-zA-Z0-9_]", "_"));
+        assert customClass != null;
+        // Register the class if it doesn't exist
+        String codeName = name.toLowerCase(Locale.ENGLISH) + "struct";
+        codeName = codeName.replaceAll("_", "underscore");
+        addLanguageNode("types." + codeName , name + " struct");
+        customClassInfo = new ClassInfo<>(customClass, codeName)
+                .user(name + " structs?( types?)?");
+
+        // hack open the Classes class to allow re-registration
+        addClassInfo(customClassInfo);
+        System.out.println("By class: " + Classes.getExactClassInfo(customClass));
+        System.out.println("By user input: " + Classes.getClassInfoFromUserInput(name + " struct"));
+    }
+
+    private void unregisterCustomType() {
+        if (customClassInfo != null) {
+            enableRegistrations();
+            removeLanguageNode("types." + customClassInfo.getCodeName());
+            removeClassInfo(customClassInfo);
+            disableRegistrations();
+            customClassInfo = null;
+            customClass = null;
+        }
+        if (classManager != null) {
+            classManager.unloadAll();
+            classManager = null;
+        }
+    }
+
+
+    @Override
+    public boolean load() {
+        var templateManager = Oopsk.getTemplateManager();
 
         // delayed parse so all fields are present
         getParser().setCurrentEvent("parse template", DynamicFieldEvalEvent.class);
         if (!template.parseFields()) {
             templateManager.removeTemplate(template);
+            unregisterCustomType();
             return false;
         }
         getParser().deleteCurrentEvent();
 
         return true;
     }
-
 
     private static final Pattern fieldPattern = Pattern.compile("(?<const>const(?:ant)? )?(?<dynamic>dynamic)?(?<name>[\\w ]+): (?<type>[\\w ]+?)(?: ?= ?(?<value>.+))?");
 
@@ -175,15 +243,11 @@ public class StructStructTemplate extends Structure {
         }
         return fields;
     }
-    @Override
-    public boolean load() {
-
-        return true;
-    }
 
     @Override
     public void unload() {
         Oopsk.getTemplateManager().removeTemplate(template);
+        unregisterCustomType();
     }
 
     @Override

--- a/src/test/scripts/basics.sk
+++ b/src/test/scripts/basics.sk
@@ -8,7 +8,7 @@ struct basic:
     d{@a}: number = {@a}
 
 test "basic struct behavior":
-    set {_struct} to a basic struct
+    set {_struct} to a basic struct instance
     assert {_struct}->a is not set with "struct field a was somehow set"
     assert {_struct}->b is not set with "struct field b was somehow set"
     assert {_struct}->c is a cow with "struct field c was not set to cow"

--- a/src/test/scripts/copies.sk
+++ b/src/test/scripts/copies.sk
@@ -3,7 +3,7 @@ struct copyable:
     copy_vectors: vectors
 
 test "copy structs":
-    set {_A} to a copyable struct:
+    set {_A} to a copyable struct instance:
         copy_num: 1
         copy_vectors: vector(1, 2, 3) and vector(4, 5, 6)
 

--- a/src/test/scripts/customtypes.sk
+++ b/src/test/scripts/customtypes.sk
@@ -1,0 +1,28 @@
+struct custom:
+    a: int = 0
+    b: strings
+    c: custom struct
+
+struct standard:
+    a: int = 1
+
+local function test(a: custom struct) returns custom struct:
+    return {_a}
+
+test "custom struct behavior":
+    set {_a} to a custom struct instance
+    set {_b} to a custom struct instance:
+        a: 5
+        b: "hello"
+        c: {_a}
+    assert {_b}->a is 5 with "struct field a was not set to 5"
+    assert {_b}->b is "hello" with "struct field b was not set to hello"
+    assert {_b}->c is {_a} with "struct field c was not set to {_a}"
+    assert {_b}->c->a is 0 with "nested struct field a was not set to 0"
+
+    assert test({_b})->c is {_a} with "function did not return the correct struct"
+    assert test({_b})->c is a custom struct with "function returned struct field b was somehow set"
+
+    parse:
+        test(a standard struct instance)
+    assert last parse logs contain "Can't understand this condition/effect" with "function did not error on wrong struct type"


### PR DESCRIPTION
Skript does not allow classinfo registration after startup. I have done it anyway.

This registers a custom type for every struct template, meaning you can now use `my struct` as a function parameter type, a return type, you can check `if {_struct} is a message struct`, and struct fields can now be limited to specific structs:
```
struct test:
    child: other struct
other struct:
    name: string
```

Please continue to be careful about when you reload files containing struct definitions. If a function in another file, for example, uses the type of an unloaded struct, it will cease to work until the struct is loaded again and the function itself is re-loaded. 
As usual, it is highly encouraged to reload everything that uses a struct after editing its definition. Continuing to use un-updated code may result in undefined behavior and strange bugs. Please report any you encounter, but know they may or may not be able to be fixed.
